### PR TITLE
fix files in horreumUpload step

### DIFF
--- a/src/main/java/jenkins/plugins/horreum/upload/HorreumUploadStep.java
+++ b/src/main/java/jenkins/plugins/horreum/upload/HorreumUploadStep.java
@@ -1,6 +1,8 @@
 package jenkins.plugins.horreum.upload;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -102,7 +104,7 @@ public final class HorreumUploadStep extends HorreumBaseStep<HorreumUploadConfig
 	}
 
 	public String getFiles() {
-		return config.getJsonFile();
+		return config.getFiles();
 	}
 
 	@DataBoundSetter

--- a/src/test/java/jenkins/plugins/horreum/HorreumUploadStepTest.java
+++ b/src/test/java/jenkins/plugins/horreum/HorreumUploadStepTest.java
@@ -2,10 +2,12 @@ package jenkins.plugins.horreum;
 
 import static io.hyperfoil.tools.HorreumTestClientExtension.dummyTest;
 import static io.hyperfoil.tools.HorreumTestClientExtension.horreumClient;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URL;
+import java.util.Map;
 
+import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -41,5 +43,42 @@ public class HorreumUploadStepTest extends HorreumPluginTestBase {
       RunService.RunsSummary summary = horreumClient.runService.listTestRuns(dummyTest.id, false, null, null, "", null);
       assertEquals(1, summary.total);
       assertEquals(1, summary.runs.size());
+   }
+
+   @Test
+   public void testUploadMultiple() throws Exception {
+      URL jsonResource1 = Thread.currentThread().getContextClassLoader().getResource("data/config-quickstart.jvm.json");
+      URL jsonResource2 = Thread.currentThread().getContextClassLoader().getResource("data/another-file.json");
+      WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "Horreum-Upload-Pipeline");
+      FilePath folder = j.jenkins.getWorkspaceFor(proj).child("run");
+      folder.child("config-quickstart.jvm.json").copyFrom(jsonResource1);
+      folder.child("another-file.json").copyFrom(jsonResource2);
+      proj.setDefinition(new CpsFlowDefinition(
+           "node {\n" +
+           "def id = horreumUpload(\n" +
+           "credentials: '" + HorreumPluginTestBase.HORREUM_UPLOAD_CREDENTIALS + "',\n" +
+           "test: '" + dummyTest.name + "',\n" +
+           "owner: '" + dummyTest.owner + "',\n" +
+           "access: 'PUBLIC',\n" +
+           "start: '1970-01-01T00:00:00.00Z',\n" +
+           "stop: '1970-01-01T00:00:01.00Z',\n" +
+           "files: '**/*.json',\n"+
+           "addBuildInfo: true\n" +
+           ")\n" +
+           "println(id)\n" +
+           "}\n",
+           true));
+      WorkflowRun run = proj.scheduleBuild2(0).get();
+      j.assertBuildStatusSuccess(run);
+      RunService.RunsSummary summary = horreumClient.runService.listTestRuns(dummyTest.id, false, null, null, "", null);
+      assertEquals(1, summary.total);
+      assertEquals(1, summary.runs.size());
+      Object runObject = horreumClient.runService.getRun(summary.runs.get(0).id,summary.runs.get(0).token);
+      assertNotNull(runObject);
+      assertTrue(runObject instanceof Map,"run should return a map");
+      Object data = ((Map)runObject).get("data");
+      assertNotNull(data);
+      assertTrue(data instanceof Map,"data should be a map");
+      assertEquals(2,((Map<?, ?>) data).size(),"data should have an entry for each file");
    }
 }


### PR DESCRIPTION
`HorreumUploadStep.getFiles()` was returning `jsonFile` instead of `files`. We tried to use `files` in a Jenkinsfile but were seeing `IllegalStateException` that should only occur when both `jsonFile` and `files` are undefined.

### Testing done

I added jenkins.plugins.horreum.HorreumUploadStepTest#testUploadMultiple to verify the change has the desired effect.

### Submitter checklist

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
